### PR TITLE
Fix requirements to point to pyserial, rather than serial

### DIFF
--- a/custom_components/cambridge_cxa/manifest.json
+++ b/custom_components/cambridge_cxa/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/lievencoghe/cambridge_cxa",
   "issue_tracker": "https://github.com/lievencoghe/cambridge_cxa/issues",
   "integration_type": "entity",
-  "requirements": ["serial"],
+  "requirements": ["pyserial"],
   "dependencies": [],
   "codeowners": [
     "@lievencoghe"


### PR DESCRIPTION
Addresses: https://github.com/lievencoghe/cambridge_cxa/issues/6

Been coming across an issue where upon restarting HA I get the error
`ImportError: cannot import name 'Serial' from 'serial' (/usr/local/lib/python3.12/site-packages/serial/__init__.py)`

This is also happening on the forum here: https://community.home-assistant.io/t/cambridge-audio-cxn-and-cxa-media-player/175992/42

Doing a `pip install pyserial --force-reinstall` within the container seems to fix it. 

Upon further investigation, I can see the integration relies on `serial` (A framework for serializing/deserializing JSON/YAML/XML into python class instances and vice versa), rather than `pyserial`. 

As such, I've gone and updated the requirements. 

This seems to have fixed my issue in between HA restarts.

Thanks for making this integration! :) 
